### PR TITLE
Restructured Device Registry Methods - Ahmad Irfan Danial

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -64,5 +64,14 @@ RUN uv pip install -r requirements_test.txt
 
 WORKDIR /workspaces
 
+# Copy the source code
+COPY . /workspaces
+
+# Expose the default Home Assistant port
+EXPOSE 8123
+
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash
+
+# Command to run Home Assistant (optional)
+CMD ["python3", "-m", "homeassistant", "--config", "/workspaces/config"]


### PR DESCRIPTION
Assigned Component/Module:
- Device Registry (_**helpers/device_registry.py**_)

Task Description:
- Restructure key functions like _**async_get_or_create**_ and _**async_update_device**_ to simplify the nested logic, remove repetitive code, and enhance overall code clarity.

Reason for Selection (Justification):
- These functions are vital to the operation of the Device Registry in Home Assistant, handling the creation and updating of device entries. The original implementations contained deeply nested logic, making them challenging to understand and maintain. Simplifying these functions will significantly improve code maintainability and readability, helping future contributors.

Reengineering Goals:
- Divide large, complex functions into smaller, modular helper functions.
- Minimize the level of nested conditional statements to make the code easier to read.
- Preserve existing behavior while increasing the testability and clarity of the code.
- Enhance in-line documentation with comments to explain key parts of the logic.

Anticipated Impact:
- The updated code will be easier to maintain and modify in the future.
- Improved readability will make it more straightforward for new developers to work with the Device Registry component.
- Higher code quality reduces the chance of bugs during future enhancements.
- Potential minor performance gains from streamlined code execution.

Reengineering Strategy:
- Begin by reorganizing the **_async_get_or_create_** function, separating out tasks like validation, device lookup, and creation into distinct helper functions.
- Proceed with simplifying the **_async_update_device_** function by isolating the processes for updating attributes, validating data, and triggering events.

